### PR TITLE
Add command-line flags

### DIFF
--- a/cmd/pokesay.go
+++ b/cmd/pokesay.go
@@ -3,26 +3,44 @@ package main
 import (
 	"bufio"
 	"encoding/binary"
+	"flag"
 	"fmt"
 	"math/rand"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/mitchellh/go-wordwrap"
 )
 
-func printSpeechBubble(scanner *bufio.Scanner, width int) {
-	border := strings.Repeat("-", width+2)
+func printSpeechBubbleLine(line string, width int) {
+	if len(line) > width {
+		fmt.Println("|", line)
+	} else {
+		fmt.Println("|", line, strings.Repeat(" ", width-len(line)), "|")
+	}
+}
+
+func printWrappedText(line string, width int, tabSpaces string) {
+	for _, wline := range strings.Split(wordwrap.WrapString(strings.Replace(line, "\t", tabSpaces, -1), uint(width)), "\n") {
+		printSpeechBubbleLine(wline, width)
+	}
+}
+
+func printSpeechBubble(scanner *bufio.Scanner, args Args) {
+	border := strings.Repeat("-", args.Width+2)
 	fmt.Println("/" + border + "\\")
+
 	for scanner.Scan() {
-		for _, wline := range strings.Split(wordwrap.WrapString(strings.Replace(scanner.Text(), "\t", "    ", -1), uint(width)), "\n") {
-			if len(wline) > width {
-				fmt.Println("| ", wline, len(wline))
-			} else {
-				fmt.Println("|", wline, strings.Repeat(" ", width-len(wline)), "|")
-			}
+		line := scanner.Text()
+
+		if !args.NoTabSpaces {
+			line = strings.Replace(line, "\t", args.TabSpaces, -1)
+		}
+		if args.NoWrap {
+			printSpeechBubbleLine(line, args.Width)
+		} else {
+			printWrappedText(line, args.Width, args.TabSpaces)
 		}
 	}
 	fmt.Println("\\" + border + "/")
@@ -36,28 +54,48 @@ func randomInt(n int) int {
 }
 
 func printPokemon() {
-	choice :=  PokemonList[randomInt(len(PokemonList))]
+	choice := PokemonList[randomInt(len(PokemonList))]
 	binary.Write(os.Stdout, binary.LittleEndian, choice.Data)
 	fmt.Printf("choice: %s / categories: %s\n", choice.Name.Name, choice.Name.Categories)
 }
 
 type Args struct {
-	Width int
+	Width       int
+	NoWrap      bool
+	TabSpaces   string
+	NoTabSpaces bool
 }
 
-func parseArgs() Args {
-	if len(os.Args) <= 1 {
-		return Args{Width: 40}
+func parseFlags() Args {
+	width := flag.Int("width", 80, "the max speech bubble width")
+	noWrap := flag.Bool("nowrap", false, "disable text wrapping (fastest)")
+	tabWidth := flag.Int("tabwidth", 4, "replace any tab characters with N spaces")
+	noTabSpaces := flag.Bool("notabspaces", false, "do not replace tab characters (fastest)")
+	fastest := flag.Bool("fastest", false, "run with the fastest possible configuration (-nowrap -notabspaces)")
+
+	flag.Parse()
+	var args Args
+
+	if *fastest {
+		args = Args{
+			Width:       *width,
+			NoWrap:      true,
+			TabSpaces:   "    ",
+			NoTabSpaces: true,
+		}
+	} else {
+		args = Args{
+			Width:       *width,
+			NoWrap:      *noWrap,
+			TabSpaces:   strings.Repeat(" ", *tabWidth),
+			NoTabSpaces: *noTabSpaces,
+		}
 	}
-	width, err := strconv.Atoi(os.Args[1])
-	if err != nil {
-		return Args{Width: 40}
-	}
-	return Args{Width: width}
+	return args
 }
 
 func main() {
-	args := parseArgs()
-	printSpeechBubble(bufio.NewScanner(os.Stdin), args.Width)
+	args := parseFlags()
+	printSpeechBubble(bufio.NewScanner(os.Stdin), args)
 	printPokemon()
 }


### PR DESCRIPTION
## Context

Edging closer towards a useable cli tool, and not just a barebones POC

This adds some handy-dandy arguments to pokesay-go, initially these are just related to the text wrapping & formatting.
In particular, use `-nowrap` for a nice speed increase.

## Changes

```text
Usage of ./pokesay:
  -fastest
        run with the fastest possible configuration (-nowrap -notabspaces)
  -notabspaces
        do not replace tab characters (fastest)
  -nowrap
        disable text wrapping (fastest)
  -tabwidth int
        replace any tab characters with N spaces (default 4)
  -width int
        the max speech bubble width (default 80)
```

- Added a `-fastest` flag which will switch all the flags to whatever the fastest mode is (if applicable)
  - currently it's equivalent to `-nowrap -notabstop`
  - `-nowrap` makes a nice difference
  - `-notabstop` is statistically insignificant, unless the size of the text is huge 

## Benchmarks

```shell
# test data:
# for i in {1..1000}; do fortune >> f.txt ; done

Summary
  'cat f.txt | ./pokesay -fastest' ran
    2.08 ± 0.27 times faster than 'cat f.txt | ./pokesay'
    2.37 ± 0.32 times faster than 'cat f.txt | $HOME/bin/pokesay'
```