### PR TITLE
Add .exe extension for Windows build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -37,5 +37,5 @@ RUN go-bindata -nometadata -nomemcopy -prefix /tmp/ /tmp/cows/... && \
 
 RUN echo "building darwin / amd64"  && GOOS=darwin  GOARCH=amd64 go build -o pokesay-darwin-amd64  cmd/pokesay.go cmd/bindata.go && \
     echo "building linux / amd64"   && GOOS=linux   GOARCH=amd64 go build -o pokesay-linux-amd64   cmd/pokesay.go cmd/bindata.go && \
-    echo "building windows / amd64" && GOOS=windows GOARCH=amd64 go build -o pokesay-windows-amd64 cmd/pokesay.go cmd/bindata.go && \
+    echo "building windows / amd64" && GOOS=windows GOARCH=amd64 go build -o pokesay-windows-amd64.exe cmd/pokesay.go cmd/bindata.go && \
     echo "building android / arm64" && GOOS=android GOARCH=arm64 go build -o pokesay-android-arm64 cmd/pokesay.go cmd/bindata.go


### PR DESCRIPTION
I probably should have made an issue. The executable for Windows is missing the `.exe` extension. While it still runs, I think it's generally better to be explicit about this on Windows builds.