### PR TITLE
Build less items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build/release: build/docker
 	@docker create --name pokesay pokesay-go:latest
 	@docker cp pokesay:/usr/local/src/pokesay-linux-amd64 .
 	@docker cp pokesay:/usr/local/src/pokesay-darwin-amd64 .
-	@docker cp pokesay:/usr/local/src/pokesay-windows-amd64 .
+	@docker cp pokesay:/usr/local/src/pokesay-windows-amd64.exe .
 	@docker cp pokesay:/usr/local/src/pokesay-android-arm64 .
 	@docker rm -f pokesay
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,7 +27,7 @@ RUN go mod tidy \
 RUN go run /usr/local/src/build/build_cows.go \
         -from /tmp/original/pokesprite/ \
         -to /tmp/cows/ \
-        -skip '["resources/", "misc/"]'
+        -skip '["resources/", "misc/", "icons/", "items/", "items-outline/"]'
 
 ADD cmd/ /usr/local/src/cmd/
 RUN go-bindata -nometadata -nomemcopy -prefix /tmp/ /tmp/cows/... && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         parallel make gcc libmagickwand-dev ncurses-dev fortune-mod fortunes
 
-ENV PATH "/usr/lib/x86_64-linux-gnu/ImageMagick-6.9.11/bin-q16:/usr/include/ImageMagick-6/:$PATH"
-RUN git clone --depth 1 git://github.com/rossy/img2xterm \
+RUN git clone --depth 1 git://github.com/denilsonsa/img2xterm \
     && (cd img2xterm && make && make install)
 
 ENV DOCKER_BUILD_DIR /tmp/original


### PR DESCRIPTION
There are currently a lot of "item" images being built and shipped, these should be removed so that "pokesay-go" is true to its name.

## Changes

- Had to change up the version of img2xterm and make some minor updates to the go build tool
- Skip over all the item directories when building cowfiles
- bonus: fixed a path in the makefile