### PR TITLE
Compress all pokemon cowfile data

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -27,17 +27,6 @@ func check(e error) {
 	}
 }
 
-type PokemonEntry struct {
-	Name       string
-	Data       []byte
-	Categories []string
-}
-
-type PokemonEntryMap struct {
-	Categories map[string][]PokemonEntry
-	Total int
-}
-
 func printSpeechBubbleLine(line string, width int) {
 	if len(line) > width {
 		fmt.Println("|", line)
@@ -88,7 +77,7 @@ func printPokemon(list pokedex.PokemonEntryMap) {
 	for _, pokemon := range list.Categories {
 		if idx == chosenCategory {
 			chosenPokemon := pokemon[randomInt(len(pokemon))]
-			binary.Write(os.Stdout, binary.LittleEndian, chosenPokemon.Data)
+			binary.Write(os.Stdout, binary.LittleEndian, pokedex.Decompress(chosenPokemon.Data))
 			fmt.Printf("choice: %s / categories: %s\n", chosenPokemon.Name, chosenPokemon.Categories)
 		}
 		idx += 1

--- a/src/pokedex.go
+++ b/src/pokedex.go
@@ -32,13 +32,13 @@ func findFiles(dirpath string, ext string, skip []string) pokedex.PokemonEntryMa
 			pokemonCategories := createCategories(fpath)
 
 			for _, c := range pokemonCategories {
-				p := pokedex.PokemonEntry{Name: createName(fpath), Categories: createCategories(fpath), Data: data}
+				p := pokedex.NewPokemonEntry(data, createName(fpath), createCategories(fpath))
 				if val, ok := categories.Categories[c]; ok {
-					val = append(val, p)
+					val = append(val, *p)
 				} else {
-					categories.Categories[c] = []pokedex.PokemonEntry{p}
+					categories.Categories[c] = []pokedex.PokemonEntry{*p}
 				}
-				categories.Categories[c] = append(categories.Categories[c], p)
+				categories.Categories[c] = append(categories.Categories[c], *p)
 			}
 		}
 		return err

--- a/src/pokedex/entries.go
+++ b/src/pokedex/entries.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/gob"
+	"compress/gzip"
 	"log"
 )
 
@@ -23,6 +24,41 @@ type PokemonEntry struct {
 type PokemonEntryMap struct {
 	Categories map[string][]PokemonEntry
 	NCategories int
+}
+
+func NewPokemonEntry(data []byte, name string, categories []string) *PokemonEntry {
+	return &PokemonEntry{
+		Name: name,
+		Categories: categories,
+		Data: Compress(data),
+	}
+}
+
+func Compress(data []byte) []byte {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+
+	_, err := gz.Write(data)
+	check(err)
+
+	err = gz.Close()
+	check(err)
+
+	return b.Bytes()
+}
+
+func Decompress(data []byte) []byte {
+	buf := bytes.NewBuffer(data)
+
+	reader, err := gzip.NewReader(buf)
+	check(err)
+
+	var resB bytes.Buffer
+
+	_, err = resB.ReadFrom(reader)
+	check(err)
+
+	return resB.Bytes()
 }
 
 func WriteToFile(categories PokemonEntryMap, fpath string) {


### PR DESCRIPTION
Currently the process takes a while to read and store the 40M of data before it can run which increased the runtime by around 40x

This is greatly reduced by gzipping the .Data field of the pokemon before writing to disk, and un-gzipping the data before printing, after we've randomly selected a pokemon

> cows.gob size 40M -> 4.8M

- current version
    ```
     22:19:01
     ☯ ~/d/pokesay-go hyperfine 'echo f | pokesay'
    
    Benchmark 1: echo f | pokesay
      Time (mean ± σ):      25.6 ms ±   1.5 ms    [User: 23.6 ms, System: 12.3 ms]
      Range (min … max):    24.0 ms …  36.4 ms    94 runs
    ```
- gzipped version
    ```
     ☯ ~/d/pokesay-go hyperfine 'echo f | ./pokesay'
    Benchmark 1: echo f | ./pokesay
      Time (mean ± σ):       7.3 ms ±   0.4 ms    [User: 8.1 ms, System: 2.2 ms]
      Range (min … max):     6.4 ms …  10.3 ms    323 runs
    ```