### PR TITLE
Log an error if a name token has no matches

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -159,8 +159,12 @@ func main() {
 	}
 
 	if args.NameToken != "" {
+		matches := collectPokemonWithToken(pokemon, args.NameToken)
+		if len(matches) == 0 {
+			log.Fatal(fmt.Sprintf("Not a valid name: '%s'", args.NameToken))
+		}
 		printSpeechBubble(bufio.NewScanner(os.Stdin), args)
-		printPokemon(chooseRandomPokemon(collectPokemonWithToken(pokemon, args.NameToken)))
+		printPokemon(chooseRandomPokemon(matches))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Currently there's an ugly error displayed if the name token has no matches, I've added a check for this