### PR TITLE
Include arm64 as a build option for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A (much) faster go version of tmck-code/pokesay
     ```shell
     bash -c "$(curl https://raw.githubusercontent.com/tmck-code/pokesay-go/master/scripts/install.sh)" bash darwin amd64
     ```
+- OSX / darwin (M1)
+    ```shell
+    bash -c "$(curl https://raw.githubusercontent.com/tmck-code/pokesay-go/master/scripts/install.sh)" bash darwin arm64
+    ```
 - Linux x64
     ```shell
     bash -c "$(curl https://raw.githubusercontent.com/tmck-code/pokesay-go/master/scripts/install.sh)" bash linux amd64

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,6 +35,7 @@ RUN go build src/pokedex.go && \
     ./pokedex -from /tmp/cows/ -to build/cows.gob
 
 RUN echo "building darwin / amd64"  && GOOS=darwin  GOARCH=amd64 go build -o pokesay-darwin-amd64      pokesay.go && \
+    echo "building darwin / arm64"  && GOOS=darwin  GOARCH=arm64 go build -o pokesay-darwin-arm64      pokesay.go && \
     echo "building linux / amd64"   && GOOS=linux   GOARCH=amd64 go build -o pokesay-linux-amd64       pokesay.go && \
     echo "building windows / amd64" && GOOS=windows GOARCH=amd64 go build -o pokesay-windows-amd64.exe pokesay.go && \
     echo "building android / arm64" && GOOS=android GOARCH=arm64 go build -o pokesay-android-arm64     pokesay.go

--- a/build/Makefile
+++ b/build/Makefile
@@ -29,6 +29,7 @@ build/release:
 	@docker create --name pokesay pokesay-go:latest
 	docker cp pokesay:/usr/local/src/pokesay-linux-amd64 .
 	docker cp pokesay:/usr/local/src/pokesay-darwin-amd64 .
+	docker cp pokesay:/usr/local/src/pokesay-darwin-arm64 .
 	docker cp pokesay:/usr/local/src/pokesay-windows-amd64.exe .
 	docker cp pokesay:/usr/local/src/pokesay-android-arm64 .
 	@docker rm -f pokesay


### PR DESCRIPTION
increases speed on m1 macs around 2x

```
Benchmark 1: echo f | ./pokesay-darwin-arm64
  Time (mean ± σ):      13.3 ms ±   0.7 ms    [User: 10.2 ms, System: 6.6 ms]
  Range (min … max):    12.4 ms …  15.6 ms    143 runs

Benchmark 1: echo f | ./pokesay-darwin-amd64
  Time (mean ± σ):      40.7 ms ±   2.7 ms    [User: 28.9 ms, System: 26.0 ms]
  Range (min … max):    32.2 ms …  46.6 ms    67 runs
```